### PR TITLE
Load the driver with the system class loader. Fixes issue loading some JDBC drivers in Logstash 6.2+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.4
+   - [JDBC input - #263](https://github.com/logstash-plugins/logstash-input-jdbc/issues/263) Load the driver with the system class loader. Fixes issue loading some JDBC drivers in Logstash 6.2+ 
+
 ## 1.0.3
   - Update gemspec summary
 

--- a/lib/logstash/plugin_mixins/jdbc_streaming.rb
+++ b/lib/logstash/plugin_mixins/jdbc_streaming.rb
@@ -43,7 +43,12 @@ module LogStash module PluginMixins module JdbcStreaming
     require "sequel"
     require "sequel/adapters/jdbc"
     require "java"
-    require @jdbc_driver_library if @jdbc_driver_library
+
+    if @jdbc_driver_library
+      class_loader = java.lang.ClassLoader.getSystemClassLoader().to_java(java.net.URLClassLoader)
+      class_loader.add_url(java.io.File.new(@jdbc_driver_library).toURI().toURL())
+    end
+
     Sequel::JDBC.load_driver(@jdbc_driver_class)
     @database = Sequel.connect(@jdbc_connection_string, :user=> @jdbc_user, :password=>  @jdbc_password.nil? ? nil : @jdbc_password.value)
     if @jdbc_validate_connection

--- a/logstash-filter-jdbc_streaming.gemspec
+++ b/logstash-filter-jdbc_streaming.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-filter-jdbc_streaming'
-  s.version         = '1.0.3'
+  s.version         = '1.0.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Enrich events with your database data"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Related to: [JDBC input - #263](https://github.com/logstash-plugins/logstash-input-jdbc/issues/263)