### PR TITLE
New connection retry mechanism

### DIFF
--- a/lib/logstash/filters/jdbc_streaming.rb
+++ b/lib/logstash/filters/jdbc_streaming.rb
@@ -4,8 +4,6 @@ require "logstash/namespace"
 require "logstash/plugin_mixins/jdbc_streaming"
 require "lru_redux"
 
-require "date"
-
 # This filter executes a SQL query and store the result set in the field
 # specified as `target`.
 # It will cache the results locally in an LRU cache with expiry

--- a/lib/logstash/filters/jdbc_streaming.rb
+++ b/lib/logstash/filters/jdbc_streaming.rb
@@ -162,10 +162,9 @@ module LogStash module Filters class JdbcStreaming < LogStash::Filters::Base
             @logger.debug? && @logger.debug("Connection reestablished")
             return execute_query(params, event)
           rescue ::Sequel::Error => recon_e
-            @logger.warn? && @logger.warn("Reconnecting failed", :exception => recon_e)
-          ensure
             @last_retry_timestamp = event.timestamp.to_f
             @@global_retry_timestamps[@global_retry_delay_label] = @last_retry_timestamp if global_retry
+            @logger.warn? && @logger.warn("Reconnecting failed", :exception => recon_e)
           end
         end
       end

--- a/lib/logstash/plugin_mixins/jdbc_streaming.rb
+++ b/lib/logstash/plugin_mixins/jdbc_streaming.rb
@@ -48,12 +48,13 @@ module LogStash module PluginMixins module JdbcStreaming
     #
     # While `connection_retry_attempts_wait_time` waits per event and thus blocks the pipeline,
     # `connection_retry_delay` skips connection retries for all events that are processed
-    # in the given time frame.
+    # in the given time frame. The filter fails for these events and the tags from
+    # `tag_on_failure` are added.
     config :connection_retry_delay, :validate => :number, :default => 300
 
-    # The delay given by `connection_retry_delay` is shared between all *jdbc_streaming*
-    # instances with the same `global_retry_delay_label`. By default (or set to an empty
-    # string) each filter instance has its own delay.
+    # The delay calculation for the next retry cycle is shared between all
+    # *jdbc_streaming* filter instances with the same `global_retry_delay_label`.
+    # By default (or set to an empty string) each filter has its own delay.
     config :global_retry_delay_label, :validate => :string
   end
 

--- a/lib/logstash/plugin_mixins/jdbc_streaming.rb
+++ b/lib/logstash/plugin_mixins/jdbc_streaming.rb
@@ -39,13 +39,17 @@ module LogStash module PluginMixins module JdbcStreaming
 
     # Maximum number of times to retry connecting to database.
     # Setting it to 0 disables connection retry.
-    #
-    # Note that while there is no connection to database when Logstash start
     config :connection_retry_attempts, :validate => :number, :default => 0
 
-    # Number of seconds to sleep between connection retry attempts
+    # Number of seconds to sleep between connection retry attempts.
     config :connection_retry_attempts_wait_time, :validate => :number, :default => 0.5
 
+    # Minimum number of seconds to wait before the next connection retry circle starts.
+    #
+    # While `connection_retry_attempts_wait_time` waits per event and thus blocks the pipeline,
+    # `connection_retry_delay` skips connection retries for all events that are processed
+    # in the given time frame.
+    config :connection_retry_delay, :validate => :number, :default => 300
   end
 
   public

--- a/lib/logstash/plugin_mixins/jdbc_streaming.rb
+++ b/lib/logstash/plugin_mixins/jdbc_streaming.rb
@@ -36,6 +36,16 @@ module LogStash module PluginMixins module JdbcStreaming
     # Connection pool configuration.
     # How often to validate a connection (in seconds)
     config :jdbc_validation_timeout, :validate => :number, :default => 3600
+
+    # Maximum number of times to retry connecting to database.
+    # Setting it to 0 disables connection retry.
+    #
+    # Note that while there is no connection to database when Logstash start
+    config :connection_retry_attempts, :validate => :number, :default => 0
+
+    # Number of seconds to sleep between connection retry attempts
+    config :connection_retry_attempts_wait_time, :validate => :number, :default => 0.5
+
   end
 
   public
@@ -50,16 +60,25 @@ module LogStash module PluginMixins module JdbcStreaming
     end
 
     Sequel::JDBC.load_driver(@jdbc_driver_class)
-    @database = Sequel.connect(@jdbc_connection_string, :user=> @jdbc_user, :password=>  @jdbc_password.nil? ? nil : @jdbc_password.value)
-    if @jdbc_validate_connection
-      @database.extension(:connection_validator)
-      @database.pool.connection_validation_timeout = @jdbc_validation_timeout
-    end
-    begin
-      @database.test_connection
-    rescue Sequel::DatabaseConnectionError => e
-      #TODO return false and let the plugin raise a LogStash::ConfigurationError
-      raise e
-    end
+    retry_jdbc_connect(@connection_retry_attempts + 1)
   end # def prepare_jdbc_connection
+
+  def retry_jdbc_connect(number_of_attempts=@connection_retry_attempts)
+    last_exception = nil
+    if number_of_attempts.times do |i|
+      begin
+        @database = Sequel.connect(@jdbc_connection_string, :user=> @jdbc_user, :password=>  @jdbc_password.nil? ? nil : @jdbc_password.value)
+        if @jdbc_validate_connection
+          @database.extension(:connection_validator)
+          @database.pool.connection_validation_timeout = @jdbc_validation_timeout
+        end
+        @database.test_connection
+        break
+      rescue ::Sequel::Error => last_exception
+        sleep @connection_retry_attempts_wait_time if i < number_of_attempts - 1
+      end
+    end == number_of_attempts
+      raise last_exception
+    end
+  end # def retry_jdbc_connect
 end end end

--- a/logstash-filter-jdbc_streaming.gemspec
+++ b/logstash-filter-jdbc_streaming.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-filter-jdbc_streaming'
-  s.version         = '1.0.5'
+  s.version         = '1.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Enrich events with your database data"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This PR adds a new mechanism that handles database connection loss. It adds 4 options to the filter:
1. `connection_retry_attempts`
The maximum number of attempts to reestablish a lost database connection.
2. `connection_retry_attempts_wait_time`
The time (in seconds) to wait between each retry attempt.
3. `connection_retry_delay`
The delay (in seconds) between each retry cycle. Makes all events in that time window fail instead of hang. Acts as a circuit breaker.
4. `global_retry_delay_label`
The delay calculation for the next retry cycle is shared between all *jdbc_streaming* filter instances with the same label.

Comments and suggestions are very welcome.