### PR TITLE
tag_on_success

### DIFF
--- a/lib/logstash/filters/jdbc_streaming.rb
+++ b/lib/logstash/filters/jdbc_streaming.rb
@@ -92,6 +92,9 @@ module LogStash module Filters class JdbcStreaming < LogStash::Filters::Base
   # Append values to the `tags` field if no record was found and default values were used
   config :tag_on_default_use, :validate => :array, :default => ["_jdbcstreamingdefaultsused"]
 
+  # Append values to the `tags` field if any records were found
+  config :tag_on_success, :validate => :array, :default => []
+
   # Enable or disable caching, boolean true or false, defaults to true
   config :use_cache, :validate => :boolean, :default => true
 
@@ -128,6 +131,7 @@ module LogStash module Filters class JdbcStreaming < LogStash::Filters::Base
       tag_default(event)
       process_event(event, @default_array)
     else
+      tag_success(event)
       process_event(event, result.payload)
     end
   end
@@ -195,6 +199,12 @@ module LogStash module Filters class JdbcStreaming < LogStash::Filters::Base
 
   def tag_default(event)
     @tag_on_default_use.each do |tag|
+      event.tag(tag)
+    end
+  end
+
+  def tag_success(event)
+    @tag_on_success.each do |tag|
       event.tag(tag)
     end
   end

--- a/lib/logstash/plugin_mixins/jdbc_streaming.rb
+++ b/lib/logstash/plugin_mixins/jdbc_streaming.rb
@@ -39,13 +39,17 @@ module LogStash module PluginMixins module JdbcStreaming
 
     # Maximum number of times to retry connecting to database.
     # Setting it to 0 disables connection retry.
-    #
-    # Note that while there is no connection to database when Logstash start
     config :connection_retry_attempts, :validate => :number, :default => 0
 
-    # Number of seconds to sleep between connection retry attempts
+    # Number of seconds to sleep between connection retry attempts.
     config :connection_retry_attempts_wait_time, :validate => :number, :default => 0.5
 
+    # Minimum number of seconds to wait before the next connection retry circle starts.
+    #
+    # While `connection_retry_attempts_wait_time` waits per event and thus blocks the pipeline,
+    # `connection_retry_delay` skips connection retries for all events that are processed
+    # in the given time frame.
+    config :connection_retry_delay, :validate => :number, :default => 300
   end
 
   public

--- a/lib/logstash/plugin_mixins/jdbc_streaming.rb
+++ b/lib/logstash/plugin_mixins/jdbc_streaming.rb
@@ -36,6 +36,16 @@ module LogStash module PluginMixins module JdbcStreaming
     # Connection pool configuration.
     # How often to validate a connection (in seconds)
     config :jdbc_validation_timeout, :validate => :number, :default => 3600
+
+    # Maximum number of times to retry connecting to database.
+    # Setting it to 0 disables connection retry.
+    #
+    # Note that while there is no connection to database when Logstash start
+    config :connection_retry_attempts, :validate => :number, :default => 0
+
+    # Number of seconds to sleep between connection retry attempts
+    config :connection_retry_attempts_wait_time, :validate => :number, :default => 0.5
+
   end
 
   public
@@ -50,16 +60,25 @@ module LogStash module PluginMixins module JdbcStreaming
     end
 
     Sequel::JDBC.load_driver(@jdbc_driver_class)
-    @database = Sequel.connect(@jdbc_connection_string, :user=> @jdbc_user, :password=>  @jdbc_password.nil? ? nil : @jdbc_password.value)
-    if @jdbc_validate_connection
-      @database.extension(:connection_validator)
-      @database.pool.connection_validation_timeout = @jdbc_validation_timeout
-    end
-    begin
-      @database.test_connection
-    rescue Sequel::DatabaseConnectionError => e
-      #TODO return false and let the plugin raise a LogStash::ConfigurationError
-      raise e
-    end
+    retry_jdbc_connect(@connection_retry_attempts + 1)
   end # def prepare_jdbc_connection
+
+  def retry_jdbc_connect(number_of_attempts=@connection_retry_attempts)
+    last_exception = nil
+    if number_of_attempts.times do |i|
+      begin
+        @database = Sequel.connect(@jdbc_connection_string, :user=> @jdbc_user, :password=>  @jdbc_password.nil? ? nil : @jdbc_password.value)
+        if @jdbc_validate_connection
+          @database.extension(:connection_validator)
+          @database.pool.connection_validation_timeout = @jdbc_validation_timeout
+        end
+        @database.test_connection
+        break
+      rescue ::Sequel::Error => last_exception
+        sleep @connection_retry_attempts_wait_time if i < number_of_attempts - 1
+      end
+    end == number_of_attempts
+      raise last_exception
+    end
+  end # def retry_jdbc_connect
 end end end

--- a/logstash-filter-jdbc_streaming.gemspec
+++ b/logstash-filter-jdbc_streaming.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-filter-jdbc_streaming'
-  s.version         = '1.0.5'
+  s.version         = '1.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Enrich events with your database data"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Adds a new setting `tag_on_success` which appends values to tags field of an event if any records were found. So it occupies the remaining seat at the tagging-options table.