### PR TITLE
reap connections when filter is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.6
+  - Fixes connection leak in pipeline reloads by properly disconnecting on plugin close
+
 ## 1.0.5
    - [#11](https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/pull/11) Swap out mysql for postgresql for testing
 

--- a/lib/logstash/filters/jdbc_streaming.rb
+++ b/lib/logstash/filters/jdbc_streaming.rb
@@ -131,6 +131,12 @@ module LogStash module Filters class JdbcStreaming < LogStash::Filters::Base
     end
   end
 
+  def close
+    @database.disconnect
+  rescue => e
+    logger.warn("Exception caught when attempting to close filter.", :exception => e.message, :backtrace => e.backtrace)
+  end
+
   # ----------------------------------------
   private
 

--- a/logstash-filter-jdbc_streaming.gemspec
+++ b/logstash-filter-jdbc_streaming.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-filter-jdbc_streaming'
-  s.version         = '1.0.5'
+  s.version         = '1.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Enrich events with your database data"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
this fixes an issue where Logstash could continue to hold a growing pool of orphaned connections to a database when the pipeline is frequently reloaded.