### PR TITLE
Fix driver loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.10
+  - Fixed driver loading [#35](https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/pull/35)
+
 ## 1.0.9
   - Added support for prepared statements [PR 32](https://github.com/logstash-plugins/logstash-filter-jdbc_streaming/pull/32)
   - Added support for `sequel_opts` to pass options to the 3rd party Sequel library.

--- a/ci/unit/Dockerfile
+++ b/ci/unit/Dockerfile
@@ -2,6 +2,7 @@ ARG ELASTIC_STACK_VERSION
 FROM docker.elastic.co/logstash/logstash:$ELASTIC_STACK_VERSION
 COPY --chown=logstash:logstash Gemfile /usr/share/plugins/plugin/Gemfile
 COPY --chown=logstash:logstash *.gemspec /usr/share/plugins/plugin/
+RUN curl -o /usr/share/logstash/postgresql.jar https://jdbc.postgresql.org/download/postgresql-42.2.8.jar
 RUN cp /usr/share/logstash/logstash-core/versions-gem-copy.yml /usr/share/logstash/versions.yml
 ENV PATH="${PATH}:/usr/share/logstash/vendor/jruby/bin"
 ENV LOGSTASH_SOURCE="1"

--- a/ci/unit/setup.sql
+++ b/ci/unit/setup.sql
@@ -1,1 +1,29 @@
 create database jdbc_streaming_db;
+
+\c jdbc_streaming_db;
+
+
+create table reference_table (
+    ip VARCHAR(50) NOT NULL,
+    name VARCHAR(50) NOT NULL,
+    location VARCHAR(50) NOT NULL
+);
+
+
+DO $$
+    DECLARE
+        counter INTEGER := 1 ;
+        ipTemplate VARCHAR(50)    := '10.%s.1.1';
+        nameTemplate VARCHAR(50) := 'ldn-server-%s';
+        locationTemplate VARCHAR(50) := 'LDN-%s-2-3';
+    BEGIN
+
+        WHILE counter <= 250
+            LOOP
+                INSERT INTO reference_table
+                VALUES ((SELECT FORMAT(ipTemplate, counter)),
+                        (SELECT FORMAT(nameTemplate, counter)),
+                        (SELECT FORMAT(locationTemplate, counter)));
+                counter = counter + 1;
+            END LOOP;
+END $$;

--- a/logstash-filter-jdbc_streaming.gemspec
+++ b/logstash-filter-jdbc_streaming.gemspec
@@ -25,5 +25,4 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'jdbc-derby'
-  s.add_development_dependency 'jdbc-postgres'
 end

--- a/logstash-filter-jdbc_streaming.gemspec
+++ b/logstash-filter-jdbc_streaming.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-filter-jdbc_streaming'
-  s.version         = '1.0.9'
+  s.version         = '1.0.10'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Enrich events with your database data"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Making the same fix to driver loading that was applied to the JDBC
input in https://github.com/logstash-plugins/logstash-input-jdbc/pull/356

This commit also reworks the test to force driver loading in the
integration tests by removing the postgres gem as a dependency and
doing all the database setup work in an external sql script)

This fixes #34 (the fix previously applied in #31 did not work correctly)