### PR TITLE
Fix Integration Tests

### DIFF
--- a/ci/unit/docker-compose.yml
+++ b/ci/unit/docker-compose.yml
@@ -15,10 +15,13 @@ services:
       LS_JAVA_OPTS: "-Xmx256m -Xms256m"
       LOGSTASH_SOURCE: 1
       PG_CONNECTION_STRING: "jdbc:postgresql://postgresql:5432"
+      POSTGRES_PASSWORD: "test_user_password"
     tty: true
 
   postgresql:
     image: postgres:latest
+    environment:
+      POSTGRES_PASSWORD: "test_user_password"
     volumes:
     - ./setup.sql:/docker-entrypoint-initdb.d/init.sql
     ports:

--- a/logstash-filter-jdbc_streaming.gemspec
+++ b/logstash-filter-jdbc_streaming.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sequel'
   s.add_runtime_dependency 'lru_redux' # lru cache with ttl
 
-  s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-devutils', '~> 1.3'
   s.add_development_dependency 'jdbc-derby'
 end

--- a/spec/filters/jdbc_streaming_spec.rb
+++ b/spec/filters/jdbc_streaming_spec.rb
@@ -1,4 +1,5 @@
 require "logstash/devutils/rspec/spec_helper"
+require "logstash/devutils/rspec/shared_examples"
 require "logstash/filters/jdbc_streaming"
 require 'jdbc/derby'
 require "sequel"

--- a/spec/integration/jdbcstreaming_spec.rb
+++ b/spec/integration/jdbcstreaming_spec.rb
@@ -1,4 +1,5 @@
 require "logstash/devutils/rspec/spec_helper"
+require "logstash/devutils/rspec/shared_examples"
 require "logstash/filters/jdbc_streaming"
 require "sequel"
 require "sequel/adapters/jdbc"
@@ -16,7 +17,10 @@ module LogStash module Filters
       "jdbc:postgresql://postgresql:5432") + "/jdbc_streaming_db?user=postgres"
 
     let(:mixin_settings) do
-      { "jdbc_driver_class" => "org.postgresql.Driver",
+      {
+        "jdbc_user" => ENV['USER'],
+        "jdbc_password" => ENV["POSTGRES_PASSWORD"],
+        "jdbc_driver_class" => "org.postgresql.Driver",
         "jdbc_driver_library" => "/usr/share/logstash/postgresql.jar",
         "jdbc_connection_string" => jdbc_connection_string
       }


### PR DESCRIPTION
Integration tests were failing due to a behavioural change in a
patch release of the postgres docker image, which now requires
a password to be set, or an explicit ENV setting to not require this.

